### PR TITLE
Deprecation/inactivation of run_Fastq_Multx 

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,5 @@
 ### Version 1.1.1
 - added KBase paper citation in PLOS format and created RELEASE_NOTES.md file
+
+### Version 2.0.0
+ - Major revision in module. Set category to deactivated in spec.json. Added deprecation announcement to display.yaml

--- a/ui/narrative/methods/run_Fastq_Multx/display.yaml
+++ b/ui/narrative/methods/run_Fastq_Multx/display.yaml
@@ -3,7 +3,7 @@
 #
 name     : Demultiplex with ea-utils FASTQ-MULTX
 tooltip  : |
-    Run the fastq-multx program from ea-utils to demultiplex a reads library into reads sets.
+    DEPRECATED - Run the fastq-multx program from ea-utils to demultiplex a reads library into reads sets.
 
 screenshots :
     []
@@ -126,10 +126,12 @@ parameter-groups:
 # Desc
 #
 description : |
+   <p>Deprecation Announcement:</p>
+   <p> This App is being deprecated due to a high fail rate: meeting the criteria for deactivation.</p>
+   <p> Demultiplex with ea-utils FASTQ-MULTX is in the process of being refactored and improved by the Kbase Team. If this app is needed for your work or analyses in KBase please contact our team.</p>
    <p>This App demultiplexes a reads library into a ReadsSet using the FASTQ-MULTX program in the EA Utils package. It is capable of automatically determining barcode IDs, and can verify that multiple reads are kept in-sync during demultiplexing.</p>
    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Dylan Chivian.</p>
 
-  
 #
 # Pubs
 #

--- a/ui/narrative/methods/run_Fastq_Multx/display.yaml
+++ b/ui/narrative/methods/run_Fastq_Multx/display.yaml
@@ -127,8 +127,8 @@ parameter-groups:
 #
 description : |
    <p>Deprecation Announcement:</p>
-   <p> This App is being deprecated due to a high fail rate: meeting the criteria for deactivation.</p>
-   <p> Demultiplex with ea-utils FASTQ-MULTX is in the process of being refactored and improved by the Kbase Team. If this app is needed for your work or analyses in KBase please contact our team.</p>
+   <p>This App is being deprecated due to a high fail rate: meeting the criteria for deactivation.</p>
+   <p>Demultiplex with ea-utils FASTQ-MULTX is in the process of being refactored and improved by the Kbase Team. If this app is needed for your work or analyses in KBase please contact our team.</p>
    <p>This App demultiplexes a reads library into a ReadsSet using the FASTQ-MULTX program in the EA Utils package. It is capable of automatically determining barcode IDs, and can verify that multiple reads are kept in-sync during demultiplexing.</p>
    <p><strong>Team members who developed & deployed algorithm in KBase:</strong> Dylan Chivian.</p>
 

--- a/ui/narrative/methods/run_Fastq_Multx/spec.json
+++ b/ui/narrative/methods/run_Fastq_Multx/spec.json
@@ -6,7 +6,7 @@
 	],
 	"contact": "help@kbase.us",
 	"visible": true,
-	"categories": ["active", "reads" ],
+	"categories": ["inactive", "reads" ],
 	"widgets": {
 		"input": null,
 		"output": "no-display"


### PR DESCRIPTION
Changed run_Fastq_Multx to inactive category through spec.json and added deprecation announcement to the display.yaml. RELEASE_NOTES were updated as well; according to the major change of status in the module.